### PR TITLE
chore: bump default APISIX Ingress version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #
 FROM golang:1.13.8 AS build-env
 
-ARG INGRESS_VERSION=0.1.0
+ARG INGRESS_VERSION=1.3.0
 LABEL ingress_version="${INGRESS_VERSION}"
 RUN rm -rf /etc/localtime \
     && ln -s /usr/share/zoneinfo/Hongkong /etc/localtime \


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

Apache APISIX Ingress v1.3 has been released. I think we should bump the default version in Dockerfile.